### PR TITLE
女性の参加者を増やす修正

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -330,6 +330,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-19
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/app/assets/stylesheets/theme.css
+++ b/app/assets/stylesheets/theme.css
@@ -7,6 +7,10 @@
   line-height: 1.5rem;
 }
 
+.bg-pink {
+  background-color: #ff69b4 !important;
+}
+
 .icon-sm {
   width: 2rem;
   height: 2rem;

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -60,6 +60,6 @@ class EventsController < ApplicationController
   private
 
   def event_params
-    params.require(:event).permit(:title, :content, :held_at, :prefecture_id, :thumbnail)
+    params.require(:event).permit(:title, :content, :held_at, :prefecture_id, :thumbnail, :only_woman)
   end
 end

--- a/app/controllers/mypage/profiles_controller.rb
+++ b/app/controllers/mypage/profiles_controller.rb
@@ -17,6 +17,6 @@ class Mypage::ProfilesController < Mypage::BaseController
   private
 
   def profile_params
-    params.require(:user).permit(:name, :avatar)
+    params.require(:user).permit(:name, :avatar, :gender)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,6 +17,6 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:email, :name, :password, :password_confirmation)
+    params.require(:user).permit(:email, :name, :password, :password_confirmation, :gender)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,8 @@ class User < ApplicationRecord
   has_many :notification_timings, through: :user_notification_timings
   has_one_attached :avatar
 
+  enum gender: { other: 0, male: 1, female: 2 }
+
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
@@ -75,5 +77,9 @@ class User < ApplicationRecord
 
   def allow_liked_event_notification?
     notification_timings.liked_event.present?
+  end
+
+  def gender_i18n
+    I18n.t("enums.user.gender.#{gender}")
   end
 end

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -6,6 +6,9 @@
     <div class="card-body">
       <h4 class="card-title fw-bold">
         <%= link_to event.title, event_path(event)  %>
+          <% if event.only_woman? %>
+          <span class="badge bg-pink">女性限定</span>
+          <% end %>
       </h4>
       <p class="card-text"><%= event.content %></p>
       <hr />

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -16,6 +16,12 @@
     <%= f.label :prefecture_id %>
     <%= f.collection_select :prefecture_id, Prefecture.all, :id, :name, {}, class: 'form-select' %>
   </div>
+  <% if current_user.female? %>
+    <div class="mb-3">
+    <%= f.check_box :only_woman %>
+    <%= f.label :only_woman, "女性限定" %>
+  </div>
+  <% end %>
   <div class="mb-3">
     <%= f.label :thumbnail %>
     <%= f.file_field :thumbnail, class: 'form-control js-file-select-preview mb-3', accept: 'image/*', data: { target: '#preview-target' } %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -13,6 +13,9 @@
             </div>
             <h1>
               <%= @event.title %>
+                <% if @event.only_woman? %>
+                <span class="badge bg-pink">女性限定</span>
+                <% end %>
             </h1>
             <% if logged_in? %>
               <div class="ms-auto">
@@ -92,7 +95,7 @@
                               method: :delete,
                               data: { confirm: 'キャンセルします' }
                   %>
-                <% else %>
+                <% elsif !@event.only_woman? || current_user.female? %>
                   <%= link_to 'このもくもく会に参加する',
                               event_attendance_url(@event),
                               class: 'btn btn-primary',

--- a/app/views/mypage/profiles/show.html.erb
+++ b/app/views/mypage/profiles/show.html.erb
@@ -31,12 +31,16 @@
       <!-- Form -->
       <%= form_with(model: @user, url: mypage_profile_path) do |f| %>
         <div class="mb-3">
-          <%= f.label :email, class: 'form-label' %>
+          <%= f.label :email, "メールアドレス", class: 'form-label' %>
           <%= f.email_field :email, class: 'form-control', required: true, placeholder: 'Email' %>
         </div>
         <div class="mb-3">
-          <%= f.label :name, class: 'form-label' %>
+          <%= f.label :name, "名前", class: 'form-label' %>
           <%= f.text_field :name, class: 'form-control', placeholder: 'らんてくん' %>
+        </div>
+        <div class="mb-3">
+          <%= f.label :gender, "性別", class: 'form-label' %>
+          <%= f.select :gender, User.genders.keys.map{ |s| [User.new(gender: s).gender_i18n, s] }, {}, { class: 'form-control', selected: :other } %>
         </div>
         <div class="col-12">
           <!-- Button -->

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -24,6 +24,10 @@
               <%= f.email_field :email, class: 'form-control' %>
             </div>
             <div class="mb-3">
+              <%= f.label :gender, "性別" %>
+              <%= f.select :gender, User.genders.keys.map{ |s| [User.new(gender: s).gender_i18n, s] }, {}, { class: 'form-control', selected: :other } %>
+            </div>
+            <div class="mb-3">
               <%= f.label :password %>
               <%= f.password_field :password, class: 'form-control' %>
             </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,3 +6,8 @@ ja:
         commented_to_event: あなたのイベントにコメントがあった時
         attended_to_event: あなたのイベントに参加申し込みがあった時
         liked_event: あなたのイベントにいいねがついた時
+    user:
+        gender:
+          other: その他
+          male: 男性
+          female: 女性

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -83,7 +83,7 @@ production:
   <<: *default
 
   # Production depends on precompilation of packs prior to booting for performance.
-  compile: false
+  compile: true
 
   # Extract and emit a css file
   extract_css: true

--- a/db/migrate/20230907011026_add_gender_to_users.rb
+++ b/db/migrate/20230907011026_add_gender_to_users.rb
@@ -1,0 +1,5 @@
+class AddGenderToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :gender, :integer
+  end
+end

--- a/db/migrate/20230907011042_add_only_woman_to_events.rb
+++ b/db/migrate/20230907011042_add_only_woman_to_events.rb
@@ -1,0 +1,5 @@
+class AddOnlyWomanToEvents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :events, :only_woman, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_19_072358) do
+ActiveRecord::Schema.define(version: 2023_09_07_011042) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -78,6 +78,7 @@ ActiveRecord::Schema.define(version: 2022_01_19_072358) do
     t.integer "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "only_woman"
     t.index ["prefecture_id"], name: "index_events_on_prefecture_id"
     t.index ["user_id"], name: "index_events_on_user_id"
   end
@@ -135,6 +136,7 @@ ActiveRecord::Schema.define(version: 2022_01_19_072358) do
     t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "gender"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 


### PR DESCRIPTION
以下の内容に沿って修正したので確認お願いします。

【実装方針】

ユーザー登録時に手入力やチェックボックス入力ではなく、セレクト形式で性別登録できる。
イベント作成画面にOnly womanのチェックボックスにチェックを入れるだけで女性限定イベントを作できる。
ユーザーが女性以外の場合、イベント作成時にOnly womanは表示されず、女性限定イベントが作成できない。
女性限定イベントには女性のみが参加できる。
女性以外の場合、女性限定イベントの詳細ページを開いた際に「このもくもく会に参加する」が表示されない。
女性限定イベントは一覧・詳細画面にて「女性限定」が表記される。
【注意点】

イベントが女性限定であるかを判定するカラムは"only_woman"とする
ユーザーの性別登録のカラムは"gender"とする
ユーザー登録時の性別のセレクト部分はenumを使って「その他・男性・女性」が表示される（その際に特に操作が無かれば"その他"が選択される）
